### PR TITLE
Add cart clear endpoint and UI button

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,8 +75,10 @@
     </section>
 
     <aside class="card">
-      <h3>Summary</h3>
-      <div id="summaryList" class="muted">None selected.</div>
+      <h3>Summary
+        <button id="clearCart" class="btn small" style="margin-left:8px;">Clear</button>
+      </h3>
+      <div id="summary">None selected.</div>
       <hr>
       <h3>Receive (Check In)</h3>
       <div class="bar" style="flex-direction:column;align-items:flex-start">
@@ -90,6 +92,6 @@
     </aside>
   </main>
 
-  <script src="./app.js?v=4"></script>
+  <script src="./app.js?v=7"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add DELETE `/cart/clear` endpoint to drop current user's cart lines
- add Clear button in Summary card and bump frontend script version
- wire up clear cart logic and disable Complete button when cart empty

## Testing
- `python -m py_compile main.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc8039a308322a78350f10da14d4c