### PR TITLE
Add read-only stock and ledger dashboard

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS idx_inventory_part_no ON inventory(part_no);
+CREATE INDEX IF NOT EXISTS idx_ledger_event_time ON ledger(event_time DESC);
+CREATE INDEX IF NOT EXISTS idx_ledger_part_no ON ledger(part_no);
+CREATE INDEX IF NOT EXISTS idx_ledger_work_order ON ledger(work_order_no);

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
     .success{color:#9ae6b4}
     .error{color:#f6ad55}
     .tag{font-size:12px;padding:2px 6px;border:1px solid #2a2f36;border-radius:999px}
+    .row{display:flex;gap:16px;flex-wrap:wrap}
+    .filters{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:8px}
   </style>
 </head>
 <body>
@@ -92,6 +94,51 @@
     </aside>
   </main>
 
-  <script src="./app.js?v=7"></script>
+  <hr/>
+  <h2>Dashboard</h2>
+  <div class="row">
+    <div class="card">
+      <h3>Stock</h3>
+      <div>
+        <input id="dash_search" placeholder="Search parts..." />
+        <button id="dash_refresh" class="btn">Refresh</button>
+        <button id="dash_export" class="btn small">Export CSV</button>
+      </div>
+      <table id="stock_tbl">
+        <thead><tr><th>Part No</th><th>Description</th><th>Available</th><th>Location</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h3>Ledger</h3>
+      <div class="filters">
+        <label>Action
+          <select id="lg_action">
+            <option value="">Any</option>
+            <option value="checkout">Checkout</option>
+            <option value="checkin">Checkin</option>
+          </select>
+        </label>
+        <input id="lg_part" placeholder="Part no" />
+        <input id="lg_wo" placeholder="Work order" />
+        <input id="lg_since" type="datetime-local" />
+        <input id="lg_until" type="datetime-local" />
+        <button id="lg_refresh" class="btn">Refresh</button>
+      </div>
+      <table id="ledger_tbl">
+        <thead>
+          <tr>
+            <th>When</th><th>User</th><th>Action</th><th>Part</th><th>Qty</th>
+            <th>Work Order</th><th>Vendor Claim</th><th>Prev→New</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- bump script to bust cache -->
+  <script src="./app.js?v=8"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `/stock` and `/ledger` endpoints for inventory snapshots and ledger history
- extend frontend with Stock and Ledger dashboard views with CSV export
- add DB indexes for inventory and ledger tables

## Testing
- `python -m py_compile main.py`
- `node --check app.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68accba89614832283b3649e039aff59