### PR TITLE
Add timestamp and one-cart constraint for checkout_cart

### DIFF
--- a/db/30_checkout_cart_timestamp.sql
+++ b/db/30_checkout_cart_timestamp.sql
@@ -1,0 +1,23 @@
+-- Add created_at on checkout_cart and ensure one cart per user.
+-- Safe to run multiple times.
+
+ALTER TABLE IF EXISTS checkout_cart
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+
+-- Guarantee one cart per user (works even if it already exists)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'uq_checkout_cart_user'
+      AND conrelid = 'checkout_cart'::regclass
+  ) THEN
+    ALTER TABLE checkout_cart
+      ADD CONSTRAINT uq_checkout_cart_user UNIQUE (user_id);
+  END IF;
+END $$;
+
+-- Optional but nice: index for ORDER BY created_at
+CREATE INDEX IF NOT EXISTS idx_checkout_cart_created_at
+  ON checkout_cart(created_at DESC);


### PR DESCRIPTION
## Summary
- add migration to add `created_at` on `checkout_cart`
- ensure only one active cart per user via unique constraint
- add index for ordering by `created_at`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adcef551dc832284ebb18e39132758